### PR TITLE
스프링 AOP 구현2 - 포인트컷 분리

### DIFF
--- a/aop/src/main/java/hello/aop/order/aop/AspectV2.java
+++ b/aop/src/main/java/hello/aop/order/aop/AspectV2.java
@@ -1,0 +1,23 @@
+package hello.aop.order.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+@Slf4j
+@Aspect
+public class AspectV2 {
+
+    //hello.aop.order 패키지와 하위 패키지
+    @Pointcut("execution(* hello.aop.order..*(..))") //포인트컷
+    private void allOrder() {} //포인트컷 시그니처
+
+    @Around("allOrder()")
+    public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable{
+        log.info("[log] {}", joinPoint.getSignature()); //join point 시그니처
+        return joinPoint.proceed();
+    }
+
+}

--- a/aop/src/test/java/hello/aop/AopTest.java
+++ b/aop/src/test/java/hello/aop/AopTest.java
@@ -3,6 +3,7 @@ package hello.aop;
 import hello.aop.order.OrderRepository;
 import hello.aop.order.OrderService;
 import hello.aop.order.aop.AspectV1;
+import hello.aop.order.aop.AspectV2;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.support.AopUtils;
@@ -10,13 +11,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @Slf4j
 @SpringBootTest
-@Import(AspectV1.class) //스프링 빈으로 등록하는 방법
+@Import(AspectV2.class) //스프링 빈으로 등록하는 방법
 public class AopTest {
 
     @Autowired


### PR DESCRIPTION
@Around 에 포인트컷 표현식을 직접 넣을 수도 있지만, @Pointcut 애노테이션으로 별도 분리 가능하다.

# @Pointcut
- @Pointcut 에 포인트컷 표현식을 사용한다.
- 메서드 이름과 파라미터를 합쳐서 포인트컷 시그니처(signature)라 한다.
- 메서드의 반환 타입은 void 여야 한다.
- 코드 내용은 비워둔다.

- 포인트컷 시그니처는 allOrder() 이다. 이름 그대로 주문과 관련된 모든 기능을 대상으로 하는 포인트컷이다.
- @Around 어드바이스에서는 포인트컷을 직접 지정해도 되지만, 포인트컷 시그니처를 사용해도 된다.
- 여기서는 @Around("allOrder()") 를 사용한다.
- 접근 제어자는 내부에서만 사용하면 private 을 사용해도 되지만, 다른 애스팩트에서 참고하려면 public 을 사용해야 한다.

포인트컷을 분리하면 하나의 포인트컷 표현식을 여러 어드바이스나, 외부 어드바이스에서도 사용할 수 있다.