### PR TITLE
스프링 AOP 구현3 - doTransaction 어드바이스 추가

### DIFF
--- a/aop/src/main/java/hello/aop/order/aop/AspectV3.java
+++ b/aop/src/main/java/hello/aop/order/aop/AspectV3.java
@@ -1,0 +1,43 @@
+package hello.aop.order.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+@Slf4j
+@Aspect
+public class AspectV3 {
+
+    //hello.aop.order 패키지와 하위 패키지
+    @Pointcut("execution(* hello.aop.order..*(..))") //포인트컷
+    private void allOrder() {} //포인트컷 시그니처
+
+    //클래스 이름 패턴이 *Service
+    @Pointcut("execution(* *..*Service.*(..))")
+    private void allService() {}
+
+    @Around("allOrder()")
+    public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        log.info("[log] {}", joinPoint.getSignature()); //join point 시그니처
+        return joinPoint.proceed();
+    }
+
+    //hello.aop.order 패키지와 하위 패키지이면서 클래스 이름 패턴이 *Service
+    @Around("allOrder() && allService()")
+    public Object doTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            log.info("[트랜잭션 시작] {}", joinPoint.getSignature());
+            Object result = joinPoint.proceed();
+            log.info("[트랜잭션 커밋] {}", joinPoint.getSignature());
+            return result;
+        } catch (Exception e) {
+            log.info("[트랜잭션 롤백] {}", joinPoint.getSignature());
+            throw e;
+        } finally {
+            log.info("[리소스 릴리즈] {}", joinPoint.getSignature());
+        }
+    }
+}

--- a/aop/src/test/java/hello/aop/AopTest.java
+++ b/aop/src/test/java/hello/aop/AopTest.java
@@ -4,6 +4,7 @@ import hello.aop.order.OrderRepository;
 import hello.aop.order.OrderService;
 import hello.aop.order.aop.AspectV1;
 import hello.aop.order.aop.AspectV2;
+import hello.aop.order.aop.AspectV3;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.support.AopUtils;
@@ -16,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 @SpringBootTest
-@Import(AspectV2.class) //스프링 빈으로 등록하는 방법
+@Import(AspectV3.class) //스프링 빈으로 등록하는 방법
 public class AopTest {
 
     @Autowired


### PR DESCRIPTION
## 트랜잭션 작동 원리
1. 핵심 로직 실행 직전에 트랜잭션을 시작
2. 핵심 로직 실행
3. 핵심 로직 실행에 문제가 없으면 커밋
4. 핵심 로직 실행에 예외가 발생하면 롤백

## AspectV3
- allOrder() 포인트컷은 hello.aop.order 패키지와 하위 패키지를 대상으로 한다.
- allService() 포인트컷은 타입 이름 패턴이 *Service 를 대상으로 한다.
ex) XxxService 처럼 Service 로 끝나는 것

## @Around("allOrder() && allService()")
- 포인트컷 조합 3가지 : && (AND), || (OR), ! (NOT)
- hello.aop.order 패키지와 하위 패키지 이면서 타입 이름 패턴이 *Service 인 것을 대상으로 한다.
- doTransaction() 어드바이스는 OrderService 에만 적용된다.
- doLog() 어드바이스는 OrderService , OrderRepository 에 모두 적용된다.


## 포인트컷이 적용된 AOP 결과
orderService : doLog() , doTransaction() 어드바이스 적용
orderRepository : doLog() 어드바이스 적용