### PR TITLE
스프링 AOP 구현4 - 포인트컷 참조

### DIFF
--- a/aop/src/main/java/hello/aop/order/aop/AspectV3.java
+++ b/aop/src/main/java/hello/aop/order/aop/AspectV3.java
@@ -1,0 +1,43 @@
+package hello.aop.order.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+@Slf4j
+@Aspect
+public class AspectV3 {
+
+    //hello.aop.order 패키지와 하위 패키지
+    @Pointcut("execution(* hello.aop.order..*(..))") //포인트컷
+    private void allOrder() {} //포인트컷 시그니처
+
+    //클래스 이름 패턴이 *Service
+    @Pointcut("execution(* *..*Service.*(..))")
+    private void allService() {}
+
+    @Around("allOrder()")
+    public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        log.info("[log] {}", joinPoint.getSignature()); //join point 시그니처
+        return joinPoint.proceed();
+    }
+
+    //hello.aop.order 패키지와 하위 패키지이면서 클래스 이름 패턴이 *Service
+    @Around("allOrder() && allService()")
+    public Object doTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            log.info("[트랜잭션 시작] {}", joinPoint.getSignature());
+            Object result = joinPoint.proceed();
+            log.info("[트랜잭션 커밋] {}", joinPoint.getSignature());
+            return result;
+        } catch (Exception e) {
+            log.info("[트랜잭션 롤백] {}", joinPoint.getSignature());
+            throw e;
+        } finally {
+            log.info("[리소스 릴리즈] {}", joinPoint.getSignature());
+        }
+    }
+}

--- a/aop/src/main/java/hello/aop/order/aop/AspectV4.java
+++ b/aop/src/main/java/hello/aop/order/aop/AspectV4.java
@@ -1,0 +1,35 @@
+package hello.aop.order.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+@Slf4j
+@Aspect
+public class AspectV4 {
+
+    @Around("hello.aop.order.aop.Pointcuts.allOrder()")
+    public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        log.info("[log] {}", joinPoint.getSignature()); //join point 시그니처
+        return joinPoint.proceed();
+    }
+
+    //hello.aop.order 패키지와 하위 패키지이면서 클래스 이름 패턴이 *Service
+    @Around("hello.aop.order.aop.Pointcuts.orderAndService()")
+    public Object doTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            log.info("[트랜잭션 시작] {}", joinPoint.getSignature());
+            Object result = joinPoint.proceed();
+            log.info("[트랜잭션 커밋] {}", joinPoint.getSignature());
+            return result;
+        } catch (Exception e) {
+            log.info("[트랜잭션 롤백] {}", joinPoint.getSignature());
+            throw e;
+        } finally {
+            log.info("[리소스 릴리즈] {}", joinPoint.getSignature());
+        }
+    }
+}

--- a/aop/src/main/java/hello/aop/order/aop/Pointcuts.java
+++ b/aop/src/main/java/hello/aop/order/aop/Pointcuts.java
@@ -1,0 +1,19 @@
+package hello.aop.order.aop;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class Pointcuts {
+
+    //hello.aop.order 패키지와 하위 패키지
+    @Pointcut("execution(* hello.aop.order..*(..))") //포인트컷
+    public void allOrder() {
+    } //포인트컷 시그니처
+
+    //클래스 이름 패턴이 *Service
+    @Pointcut("execution(* *..*Service.*(..))")
+    public void allService() {
+    }
+
+    @Pointcut("allOrder() && allService()")
+    public void orderAndService() {}
+}

--- a/aop/src/test/java/hello/aop/AopTest.java
+++ b/aop/src/test/java/hello/aop/AopTest.java
@@ -4,6 +4,7 @@ import hello.aop.order.OrderRepository;
 import hello.aop.order.OrderService;
 import hello.aop.order.aop.AspectV1;
 import hello.aop.order.aop.AspectV2;
+import hello.aop.order.aop.AspectV3;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.support.AopUtils;
@@ -16,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 @SpringBootTest
-@Import(AspectV2.class) //스프링 빈으로 등록하는 방법
+@Import(AspectV3.class) //스프링 빈으로 등록하는 방법
 public class AopTest {
 
     @Autowired

--- a/aop/src/test/java/hello/aop/AopTest.java
+++ b/aop/src/test/java/hello/aop/AopTest.java
@@ -5,6 +5,7 @@ import hello.aop.order.OrderService;
 import hello.aop.order.aop.AspectV1;
 import hello.aop.order.aop.AspectV2;
 import hello.aop.order.aop.AspectV3;
+import hello.aop.order.aop.AspectV4;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.support.AopUtils;
@@ -17,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 @SpringBootTest
-@Import(AspectV3.class) //스프링 빈으로 등록하는 방법
+@Import(AspectV4.class) //스프링 빈으로 등록하는 방법
 public class AopTest {
 
     @Autowired


### PR DESCRIPTION
## 주요 내용
- 포인트컷을 공용으로 사용하기 위해 별도의 외부 클래스에 모아두어도 된다.
- 외부에서 호출할 때는 포인트컷의 접근 제어자를 public 으로 열어두어야 한다.