### PR TITLE
스프링 AOP 구현5 - 어드바이스 순서

### DIFF
--- a/aop/src/main/java/hello/aop/order/aop/AspectV4Pointcut.java
+++ b/aop/src/main/java/hello/aop/order/aop/AspectV4Pointcut.java
@@ -4,11 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Pointcut;
 
 @Slf4j
 @Aspect
-public class AspectV4 {
+public class AspectV4Pointcut {
 
     @Around("hello.aop.order.aop.Pointcuts.allOrder()")
     public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {

--- a/aop/src/main/java/hello/aop/order/aop/AspectV5Order.java
+++ b/aop/src/main/java/hello/aop/order/aop/AspectV5Order.java
@@ -1,0 +1,45 @@
+package hello.aop.order.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+
+@Slf4j
+@Aspect
+public class AspectV5Order {
+
+    @Aspect
+    @Order(2)
+    public static class LogAspect{
+        @Around("hello.aop.order.aop.Pointcuts.allOrder()")
+        public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+
+            log.info("[log] {}", joinPoint.getSignature()); //join point 시그니처
+            return joinPoint.proceed();
+        }
+    }
+
+
+    @Aspect
+    @Order(1)
+    public static class TxAspect{
+        //hello.aop.order 패키지와 하위 패키지이면서 클래스 이름 패턴이 *Service
+        @Around("hello.aop.order.aop.Pointcuts.orderAndService()")
+        public Object doTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+            try {
+                log.info("[트랜잭션 시작] {}", joinPoint.getSignature());
+                Object result = joinPoint.proceed();
+                log.info("[트랜잭션 커밋] {}", joinPoint.getSignature());
+                return result;
+            } catch (Exception e) {
+                log.info("[트랜잭션 롤백] {}", joinPoint.getSignature());
+                throw e;
+            } finally {
+                log.info("[리소스 릴리즈] {}", joinPoint.getSignature());
+            }
+        }
+    }
+
+}

--- a/aop/src/test/java/hello/aop/AopTest.java
+++ b/aop/src/test/java/hello/aop/AopTest.java
@@ -2,10 +2,7 @@ package hello.aop;
 
 import hello.aop.order.OrderRepository;
 import hello.aop.order.OrderService;
-import hello.aop.order.aop.AspectV1;
-import hello.aop.order.aop.AspectV2;
-import hello.aop.order.aop.AspectV3;
-import hello.aop.order.aop.AspectV4;
+import hello.aop.order.aop.*;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.support.AopUtils;
@@ -18,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 @SpringBootTest
-@Import(AspectV4.class) //스프링 빈으로 등록하는 방법
+@Import({AspectV5Order.LogAspect.class, AspectV5Order.TxAspect.class}) //스프링 빈으로 등록하는 방법
 public class AopTest {
 
     @Autowired


### PR DESCRIPTION
## 주요 내용

- 어드바이스는 기본적으로 순서를 보장하지 않는다. 
순서를 지정하고 싶으면 @Aspect 적용 단위로 @Order 애노테이션을 적용해야 한다. 

    - 문제는 이것을 어드바이스 단위가 아니라 **클래스 단위**로 적용해야 한다.
따라서 애스펙트를 별도의 클래스로 분리했다.

- 현재 로그를 남기는 순서는 로그 -> 트랜잭션 이다.
로그를 남기는 순서를 바꾸어서 트랜잭션이 먼저 처리되고, 이후에 로그가 남도록 변경했다.